### PR TITLE
[FIX]: codeblock component was printing code to screen.. weird

### DIFF
--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -37,7 +37,6 @@ const CodeBlock = ({
         </code>
       </pre>
       <P styleProps={["italic"]}>{caption}</P>
-      <div>{code}</div>
     </div>
   );
 };

--- a/app/routes/braindumps.list.$braindumpId.tsx
+++ b/app/routes/braindumps.list.$braindumpId.tsx
@@ -33,7 +33,6 @@ type LoaderData = {
 };
 
 export const loader: LoaderFunction = async ({ params }) => {
-
   /* 1. retrieve the Notion Page equivalent of this Braindump */
   const response: Page = await notionClient.pages.retrieve({
     page_id: params.braindumpId,
@@ -306,12 +305,13 @@ const useNotionInterpretBlocks = (
             return null;
 
           case "code":
-            // todo: throw an error if a code block is missing a caption
             return (
               <CodeBlock
                 key={block.id}
                 content={{
-                  caption: block.code.caption[0].plain_text,
+                  ...(block.code.caption[0] && {
+                    caption: block.code.caption[0].plain_text,
+                  }),
                   code: block.code.rich_text[0].plain_text,
                 }}
               />


### PR DESCRIPTION
It turns out it wasn't a backtick issue. The code wasn't compiling because I was expecting a `code caption` which wasn't set.